### PR TITLE
Send messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ two switches (of_switch, linked via a port_of to an of_port, the of_port linked 
 #Monitor Identifiers
 Clients can connect to a websocket to monitor identifiers for changes to
 identifiers' metadata and links. The URI of the websocket is
-`/dobby/monitor`. A simple test client is at `/dobby/monitor/test`.
+`/dobby/monitor`. A simple test client is at `/dobby/monitor/test/index.html`.
 
 ##Starting
 Clients start monitoring Identifiers by sending the following JSON

--- a/src/dbyr_monitor.erl
+++ b/src/dbyr_monitor.erl
@@ -175,8 +175,9 @@ delta_fn() ->
 delta_metadata(_, Metadata, Metadata) ->
     [];
 delta_metadata(Identifier, _, NewMetadata) ->
-    [#{<<"identifier">> => Identifier,
-      <<"metadata">> => NewMetadata}].
+    monitor_event(<<"create">>,
+        #{<<"identifier">> => Identifier,
+          <<"metadata">> => NewMetadata}).
 
 delta_links(OldLinks, NewLinks) ->
     OldMap = links_map(OldLinks),
@@ -199,7 +200,7 @@ delivery_fn(#{websocket_pid := WebsocketPid}) ->
     fun(Messages) ->
         lists:foreach(
             fun(Message) ->
-                lr_monitor_handler:send(WebsocketPid, jiffy:encode(Message))
+                dbyr_monitor_handler:send(WebsocketPid, jiffy:encode(Message))
             end, Messages),
         ok
     end.


### PR DESCRIPTION
Fix path in readme to test UI.

Call the correct function to send messages to the websocket. Correct the metadata change message.
