### PR TITLE
Fix monitor messages

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,8 @@
 ]}.
 
 {deps,[
+    {dobby, ".*", {git, "https://github.com/ivanos/dobby_core_lib.git", {branch,"master"}}}, % for testing
+    {websocket_client, ".*", {git, "https://github.com/jeremyong/websocket_client.git", {tag,"v0.7"}}}, % for testing
     {dobby_clib, ".*", {git, "https://github.com/ivanos/dobby_clib.git", {branch,"master"}}},
     {lager,      ".*", {git, "https://github.com/basho/lager.git", {tag,"2.1.1"}}}, 
     {erl_cowboy, ".*", {git, "https://github.com/ivanos/erl_cowboy.git", {branch,"master"}}},

--- a/test/dbyr_SUITE.erl
+++ b/test/dbyr_SUITE.erl
@@ -1,0 +1,175 @@
+%%%=============================================================================
+%%% @copyright (C) 2015, Erlang Solutions Ltd
+%%% @author Marc Sugiyama <marc.sugiyama@erlang-solutions.com>
+%%% @doc Dobby system test
+%%% @end
+%%%=============================================================================
+-module(dbyr_SUITE).
+-copyright("2015, Erlang Solutions Ltd.").
+
+%% Note: This directive should only be used in test suites.
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PUBLISHER_ID, <<"PUBLISHER">>).
+
+%%%=============================================================================
+%%% Callbacks
+%%%=============================================================================
+
+
+suite() ->
+    [{timetrap,{minutes,10}}].
+
+init_per_suite(Config) ->
+    start_applications(),
+    case is_dobby_server_running() of
+        false ->
+            ct:pal(Reason = "Dobby server is not running"),
+            {skip, Reason};
+        true ->
+            Config
+    end.
+
+end_per_testcase(_,_) ->
+    % clean up graph
+    Identifiers = dby:search(search_fn1(), [], <<"A">>, [depth, {max_depth, 100}]),
+    ok = dby:publish(?PUBLISHER_ID,
+        [{Identifier, delete} || Identifier <- Identifiers], [persistent]).
+
+all() ->
+    [search1,
+     delete1,
+     subscription1,
+     subscription2].
+
+%%%=============================================================================
+%%% Testcases
+%%%=============================================================================
+
+search1(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Graph = graph(),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+
+    %% THEN
+    ?assertEqual(
+        Identifiers,
+        lists:sort(
+            dby:search(search_fn1(), [], <<"A">>, [depth, {max_depth, 10}]))),
+    ?assertEqual(
+        [<<"A">>,<<"B">>,<<"C">>,<<"E">>],
+        lists:sort(
+            dby:search(search_fn1(), [], <<"A">>, [depth, {max_depth, 1}]))),
+    ?assertEqual(
+        [<<"A">>,<<"B">>,<<"C">>,<<"E">>],
+        lists:sort(
+            dby:search(search_fn1(), [], <<"A">>, [breadth, {max_depth, 1}]))).
+
+-define(KEY, <<"when">>).
+delete1(_Config) ->
+    %% GIFEN
+    Identifier = <<"A">>,
+    AfterMeta = <<"after delete">>,
+    BeforeIdentifier = {Identifier, [{?KEY, <<"before delete">>}]},
+    AfterIdentifier = {Identifier, [{?KEY, AfterMeta}]},
+    ok = dby:publish(?PUBLISHER_ID, [BeforeIdentifier], [persistent]),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, [{Identifier, delete},
+                                     AfterIdentifier], [persistent]),
+
+    %% THEN
+    ?assertMatch(
+        #{?KEY := #{value := AfterMeta}},
+        dby:identifier(Identifier)).
+
+subscription1(_Config) ->
+    %% GIVEN
+    Graph = graph(),
+    Ref = make_ref(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    {ok, _, _} = dby:subscribe(search_fn1(), [], <<"A">>,
+        [depth, {max_depth, 10}, persistent,
+            {delta, delta_fn1()}, {delivery, delivery_fn1(Ref)}]),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, [{<<"A">>, <<"Q">>, []}], [persistent]),
+
+    %% THEN
+    receive
+        {Ref, Msg} ->
+            ?assertEqual([<<"Q">>], Msg)
+    end.
+
+subscription2(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Graph = graph(),
+    Ref = make_ref(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    {ok, _, _} = dby:subscribe(search_fn1(), [], <<"A">>,
+        [depth, {max_depth, 10}, message,
+            {delta, delta_fn1()}, {delivery, delivery_fn1(Ref)}]),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, [{<<"A">>, <<"Q">>, []}], [message]),
+
+    %% THEN
+    receive
+        {Ref, Msg} ->
+            ?assertEqual([<<"Q">>], Msg)
+    end,
+    ?assertEqual(
+        Identifiers,
+        lists:sort(
+            dby:search(search_fn1(), [], <<"A">>, [depth, {max_depth, 10}]))).
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+start_applications() ->
+    ok = application:set_env(erl_mnesia, options, [persistent]),
+    application:ensure_all_started(dobby).
+
+is_dobby_server_running() ->
+    proplists:is_defined(dobby, application:which_applications()).
+
+% search function returns list of identifiers
+search_fn1() ->
+    fun(Identifier, _, _, Acc) ->
+        {continue, [Identifier | Acc]}
+    end.
+
+% delta function returns what's new in the list
+delta_fn1() ->
+    fun(OldAcc, NewAcc) ->
+        {delta, NewAcc -- OldAcc}
+    end.
+
+% delivery function sends the message to the pid: {Ref, Delta}
+delivery_fn1(Ref) ->
+    Target = self(),
+    fun(Delta) ->
+        Target ! {Ref, Delta},
+        ok
+    end.
+
+identifiers() ->
+    [<<"A">>,<<"B">>,<<"C">>,<<"D">>,<<"E">>,<<"F">>,<<"G">>].
+
+graph() ->
+    [
+        {<<"A">>,<<"B">>, []},
+        {<<"A">>,<<"C">>, []},
+        {<<"A">>,<<"E">>, []},
+        {<<"B">>,<<"D">>, []},
+        {<<"B">>,<<"F">>, []},
+        {<<"C">>,<<"G">>, []},
+        {<<"E">>,<<"F">>, []}
+    ].

--- a/test/dbyr_ws_SUITE.erl
+++ b/test/dbyr_ws_SUITE.erl
@@ -1,0 +1,339 @@
+%%%=============================================================================
+%%% @copyright (C) 2015, Erlang Solutions Ltd
+%%% @author Marc Sugiyama <marc.sugiyama@erlang-solutions.com>
+%%% @doc Dobby system test
+%%% @end
+%%%=============================================================================
+-module(dbyr_ws_SUITE).
+-copyright("2015, Erlang Solutions Ltd.").
+
+%% Note: This directive should only be used in test suites.
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PUBLISHER_ID, <<"PUBLISHER">>).
+-define(WS_URL, "ws://localhost:8080/dobby/monitor").
+-define(PORT, 8080).
+
+%%%=============================================================================
+%%% Callbacks
+%%%=============================================================================
+
+
+suite() ->
+    [{timetrap,{minutes,10}}].
+
+init_per_suite(Config) ->
+    start_applications(),
+    case is_dobby_server_running() of
+        false ->
+            ct:pal(Reason = "Dobby server is not running"),
+            {skip, Reason};
+        true ->
+            Config
+    end.
+
+end_per_testcase(_,_) ->
+    dby_db:clear().
+
+all() ->
+    [create_monitor,
+     change_identifier_metadata,
+     delete_identifier_metadata,
+     add_identifier_metadata,
+     delete_identifier,
+%    create_identifier,
+     add_link,
+     remove_link,
+     change_link_metadata,
+     delete_link_metadata,
+     add_link_metadata].
+
+%%%=============================================================================
+%%% Testcases
+%%%=============================================================================
+
+
+create_monitor(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Identifier = hd(Identifiers),
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    {ok, WS} = ws_client:start_link(?WS_URL),
+
+    %% WHEN
+    ws_client:send_text(WS, monitor(Identifier)),
+
+    %% THEN
+    {text, ReplyText} = ws_client:recv(WS),
+    Reply = jiffy:decode(ReplyText, [return_maps]),
+    ?assertEqual(<<"response">>, maps:get(<<"type">>, Reply)),
+    ?assertEqual(sequence(), maps:get(<<"sequence">>, Reply)),
+    [State] = maps:get(<<"state">>, maps:get(<<"response">>, Reply)),
+    ?assertEqual(Identifier, maps:get(<<"identifier">>, State)),
+
+    stop_ws(WS).
+
+change_identifier_metadata(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Identifier = hd(Identifiers),
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    WS = start_monitor(Identifier),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, [{<<"key1">>,<<"data1">>}]}, [persistent]),
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, [{<<"key1">>,<<"data2">>}]}, [persistent]),
+
+    %% THEN
+    {Identifier, Metadata1, _} = recv_event(WS, <<"create">>),
+    ?assertEqual(<<"data1">>, metadata_get(<<"key1">>, Metadata1)),
+    {Identifier, Metadata2, _} = recv_event(WS, <<"create">>),
+    ?assertEqual(<<"data2">>, metadata_get(<<"key1">>, Metadata2)),
+
+    stop_ws(WS).
+
+delete_identifier_metadata(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Identifier = hd(Identifiers),
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, [{<<"key1">>,<<"data1">>}]}, [persistent]),
+    WS = start_monitor(Identifier),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, [{<<"key1">>, delete}]}, [persistent]),
+
+    %% THEN
+    {Identifier, Metadata, _} = recv_event(WS, <<"create">>),
+    ?assertEqual(#{}, Metadata),
+
+    stop_ws(WS).
+
+add_identifier_metadata(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Identifier = hd(Identifiers),
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, [{<<"key1">>,<<"data1">>}]}, [persistent]),
+    WS = start_monitor(Identifier),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, [{<<"key2">>,<<"data2">>}]}, [persistent]),
+
+    %% THEN
+    {Identifier, Metadata, _} = recv_event(WS, <<"create">>),
+    ?assertEqual(<<"data2">>, metadata_get(<<"key2">>, Metadata)),
+
+    stop_ws(WS).
+
+delete_identifier(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Identifier = hd(Identifiers),
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    WS = start_monitor(Identifier),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, delete}, [persistent]),
+
+    %% THEN
+    {Identifier, undefined, _} = recv_event(WS, <<"delete">>),
+
+    stop_ws(WS).
+
+% XXX functionality not implemented
+create_identifier(_Config) ->
+    %% GIVEN
+    Identifier = <<"A">>,
+    WS = start_monitor(Identifier),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier, [{<<"key1">>,<<"data1">>}]}, [persistent]),
+
+    %% THEN
+    {Identifier, Metadata, _} = recv_event(WS, <<"create">>),
+    ?assertEqual(<<"data1">>, metadata_get(<<"key1">>, Metadata)).
+
+add_link(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    Identifier1 = hd(Identifiers),
+    Identifier2 = lists:last(Identifiers),
+    no_link(Identifier1, Identifier2),
+    LinkString = <<Identifier1/binary, $/, Identifier2/binary>>,
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    WS = start_monitor(Identifier1),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, []}, [persistent]),
+
+    %% THEN
+    {undefined, _, Links} = recv_event(WS, <<"create">>),
+    [Link] = Links,
+    ?assertEqual(LinkString, maps:get(<<"link">>, Link)),
+
+    stop_ws(WS).
+
+remove_link(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    [Identifier1, Identifier2 | _] = Identifiers,
+    LinkString = <<Identifier1/binary, $/, Identifier2/binary>>,
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, []}, [persistent]),
+    WS = start_monitor(Identifier1),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, delete}, [persistent]),
+
+    %% THEN
+    {undefined, _, Links} = recv_event(WS, <<"delete">>),
+    ?assertEqual([LinkString], Links),
+
+    stop_ws(WS).
+
+change_link_metadata(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    [Identifier1, Identifier2 | _] = Identifiers,
+    LinkString = <<Identifier1/binary, $/, Identifier2/binary>>,
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, [{<<"key1">>,<<"data1">>}]}, [persistent]),
+    WS = start_monitor(Identifier1),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, [{<<"key1">>, <<"data2">>}]}, [persistent]),
+
+    %% THEN
+    {undefined, _, Links} = recv_event(WS, <<"create">>),
+    [Link] = Links,
+    ?assertEqual(LinkString, maps:get(<<"link">>, Link)),
+    Metadata = maps:get(<<"metadata">>, Link),
+    ?assertEqual(<<"data2">>, metadata_get(<<"key1">>, Metadata)),
+
+    stop_ws(WS).
+
+delete_link_metadata(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    [Identifier1, Identifier2 | _] = Identifiers,
+    LinkString = <<Identifier1/binary, $/, Identifier2/binary>>,
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, [{<<"key1">>,<<"data1">>}]}, [persistent]),
+    WS = start_monitor(Identifier1),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, [{<<"key1">>, delete}]}, [persistent]),
+
+    %% THEN
+    {undefined, _, Links} = recv_event(WS, <<"create">>),
+    [Link] = Links,
+    ?assertEqual(LinkString, maps:get(<<"link">>, Link)),
+    ?assertEqual(#{}, maps:get(<<"metadata">>, Link)),
+
+    stop_ws(WS).
+
+add_link_metadata(_Config) ->
+    %% GIVEN
+    Identifiers = identifiers(),
+    [Identifier1, Identifier2 | _] = Identifiers,
+    LinkString = <<Identifier1/binary, $/, Identifier2/binary>>,
+    Graph = graph(),
+    ok = dby:publish(?PUBLISHER_ID, Graph, [persistent]),
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, []}, [persistent]),
+    WS = start_monitor(Identifier1),
+
+    %% WHEN
+    ok = dby:publish(?PUBLISHER_ID, {Identifier1, Identifier2, [{<<"key1">>,<<"data1">>}]}, [persistent]),
+
+    %% THEN
+    {undefined, _, Links} = recv_event(WS, <<"create">>),
+    [Link] = Links,
+    ?assertEqual(LinkString, maps:get(<<"link">>, Link)),
+    Metadata = maps:get(<<"metadata">>, Link),
+    ?assertEqual(<<"data1">>, metadata_get(<<"key1">>, Metadata)),
+
+    stop_ws(WS).
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+start_applications() ->
+    ok = application:set_env(erl_mnesia, options, [persistent]),
+    ok = application:set_env(erl_cowboy, port, ?PORT),
+    application:ensure_all_started(dobby),
+    application:ensure_all_started(dobby_rest).
+
+is_dobby_server_running() ->
+    proplists:is_defined(dobby, application:which_applications()).
+
+% search function returns list of identifiers
+search_fn1() ->
+    fun(Identifier, _, _, Acc) ->
+        {continue, [Identifier | Acc]}
+    end.
+
+identifiers() ->
+    [<<"A">>,<<"B">>,<<"C">>,<<"D">>,<<"E">>,<<"F">>,<<"G">>].
+
+graph() ->
+    [
+        {<<"A">>,<<"B">>, []},
+        {<<"A">>,<<"C">>, []},
+        {<<"A">>,<<"E">>, []},
+        {<<"B">>,<<"D">>, []},
+        {<<"B">>,<<"F">>, []},
+        {<<"C">>,<<"G">>, []},
+        {<<"E">>,<<"F">>, []}
+    ].
+
+sequence() ->
+    <<"1">>.
+
+monitor(Identifier) ->
+    jiffy:encode(
+        #{
+            <<"type">> => <<"start">>,
+            <<"sequence">> => sequence(),
+            <<"monitor">> => <<"identifier">>,
+            <<"parameters">> => #{
+                <<"identifiers">> => [Identifier]
+            }
+        }).
+
+recv_event(WS, Event) ->
+    {text, ReplyText} = ws_client:recv(WS),
+    Reply = jiffy:decode(ReplyText, [return_maps]),
+    ?assertEqual(<<"event">>, maps:get(<<"type">>, Reply)),
+    ?assertEqual(Event, maps:get(<<"event">>, Reply)),
+    Message = maps:get(<<"message">>, Reply),
+    {maps:get(<<"identifier">>, Message, undefined),
+     maps:get(<<"metadata">>, Message, undefined),
+     maps:get(<<"links">>, Message, undefined)}.
+
+metadata_get(Key, Metadata) ->
+    maps:get(<<"value">>, maps:get(Key, Metadata)).
+
+start_monitor(Identifier) ->
+    {ok, WS} = ws_client:start_link(?WS_URL),
+    ws_client:send_text(WS, monitor(Identifier)),
+    {text, _} = ws_client:recv(WS),
+    WS.
+
+stop_ws(WS) ->
+    ws_client:stop(WS).
+
+no_link(Id1, Id2) ->
+    ?assert(not lists:any(fun({A, B, _}) -> A == Id1 andalso B == Id2 end, graph())).

--- a/test/ws_client.erl
+++ b/test/ws_client.erl
@@ -1,0 +1,77 @@
+% based on ct/ws_client.erl from
+% https://github.com/jeremyong/websocket_client.git
+
+-module(ws_client).
+
+-behaviour(websocket_client_handler).
+
+-export([
+         start_link/1,
+         send_text/2,
+         send_binary/2,
+         send_ping/2,
+         recv/2,
+         recv/1,
+         stop/1
+        ]).
+
+-export([
+         init/2,
+         websocket_handle/3,
+         websocket_info/3,
+         websocket_terminate/3
+        ]).
+
+-record(state, {
+          buffer = [] :: list(),
+          waiting = undefined :: undefined | pid()
+         }).
+
+start_link(Url) ->
+    websocket_client:start_link(Url, ?MODULE, []).
+
+stop(Pid) ->
+    Pid ! stop.
+
+send_text(Pid, Msg) ->
+    websocket_client:cast(Pid, {text, Msg}).
+
+send_binary(Pid, Msg) ->
+    websocket_client:cast(Pid, {binary, Msg}).
+
+send_ping(Pid, Msg) ->
+    websocket_client:cast(Pid, {ping, Msg}).
+
+recv(Pid) ->
+    recv(Pid, 5000).
+
+recv(Pid, Timeout) ->
+    Pid ! {recv, self()},
+    receive
+        M -> M
+    after
+        Timeout -> timeout_error
+    end.
+
+init(_, _WSReq) ->
+    {ok, #state{}}.
+
+websocket_handle(Frame, _, State = #state{waiting = undefined, buffer = Buffer}) ->
+    io:format("Client received frame~n"),
+    {ok, State#state{buffer = [Frame|Buffer]}};
+websocket_handle(Frame, _, State = #state{waiting = From}) ->
+    io:format("Client received frame~n"),
+    From ! Frame,
+    {ok, State#state{waiting = undefined}}.
+
+websocket_info({recv, From}, _, State = #state{buffer = []}) ->
+    {ok, State#state{waiting = From}};
+websocket_info({recv, From}, _, State = #state{buffer = [Top|Rest]}) ->
+    From ! Top,
+    {ok, State#state{buffer = Rest}};
+websocket_info(stop, _, State) ->
+    {close, <<>>, State}.
+
+websocket_terminate(Close, _, State) ->
+    io:format("Websocket closed with frame ~p and state ~p", [Close, State]),
+    ok.


### PR DESCRIPTION
Monitor was not sending the correct messages for identifier changes, or any messages for changes to link metadata.
Adds automated common tests.
Adds dependencies needed for the common tests.
